### PR TITLE
Move internal packages to be exposed

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/einride/xsens-go/internal/xsens"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
@@ -89,7 +88,7 @@ func TestReadGNSS(t *testing.T) {
 	}()
 
 	var dataIsSet bool
-	err := x.readMessages(func(data *xsens.Data, err error) {
+	err := x.readMessages(func(data *Data, err error) {
 		dataIsSet = true
 	})
 
@@ -119,7 +118,7 @@ func TestSkipGNSS(t *testing.T) {
 		err = writer.Close()
 		assert.Nil(t, err)
 	}()
-	err := x.readMessages(func(data *xsens.Data, err error) {
+	err := x.readMessages(func(data *Data, err error) {
 		assert.Equal(t, 13.37, data.Latlng.Lng)
 		assert.Equal(t, 42.0, data.Latlng.Lat)
 	})
@@ -139,7 +138,7 @@ func TestReadMsgs(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	err := x.readMessages(func(data *xsens.Data, err error) {
+	err := x.readMessages(func(data *Data, err error) {
 		assert.Equal(t, 42.0, data.Latlng.Lat)
 		assert.Equal(t, 13.37, data.Latlng.Lng)
 		assert.Nil(t, err)
@@ -161,7 +160,7 @@ func TestReadTwoMsgs(t *testing.T) {
 		assert.Nil(t, err)
 	}()
 
-	err := x.readMessages(func(data *xsens.Data, err error) {
+	err := x.readMessages(func(data *Data, err error) {
 		assert.Equal(t, 42.0, data.Latlng.Lat)
 		assert.Equal(t, 13.37, data.Latlng.Lng)
 		assert.Nil(t, err)

--- a/cmd/xsens/main.go
+++ b/cmd/xsens/main.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"github.com/einride/xsens-go"
-	"github.com/einride/xsens-go/internal/xsens"
 	"go.uber.org/zap"
 )
 
@@ -22,7 +21,7 @@ func main() {
 	}
 
 	defer client.Close()
-	err = client.Run(func(data *xsens.Data, err error) {
+	err = client.Run(func(data *xsensgo.Data, err error) {
 		if err != nil {
 			logger.Warn("Got error from xsens data %v", zap.Error(err))
 			return

--- a/decodeData.go
+++ b/decodeData.go
@@ -1,4 +1,4 @@
-package xsens
+package xsensgo
 
 import (
 	"bytes"

--- a/decodeData_test.go
+++ b/decodeData_test.go
@@ -1,4 +1,4 @@
-package xsens
+package xsensgo
 
 import (
 	"log"

--- a/xsensData.go
+++ b/xsensData.go
@@ -1,4 +1,4 @@
-package xsens
+package xsensgo
 
 import (
 	"bytes"
@@ -181,7 +181,7 @@ func (fp xsens1632) ToFloat() float64 {
 	return float64(i) / math.Pow(2, 32)
 }
 
-func CheckIfGNSS(data []byte) bool {
+func checkIfGNSS(data []byte) bool {
 	packets, err := parsePackets(bytes.NewReader(data))
 	if err != nil {
 		log.Printf("Error parsing packets: %v", err)

--- a/xsensData_test.go
+++ b/xsensData_test.go
@@ -1,4 +1,4 @@
-package xsens
+package xsensgo
 
 import (
 	"bytes"


### PR DESCRIPTION
Internal packages need to be exposed in order to return data
to the user of the library. Files in the internal folder should
not need to be exposed