### PR TITLE
chore: simplify tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,7 @@ all: \
 
 include tools/git-verify-nodiff/rules.mk
 include tools/golangci-lint/rules.mk
-include tools/gomock/rules.mk
 include tools/goreview/rules.mk
-include tools/xtools/rules.mk
 
 .PHONY: go-test
 go-test:
@@ -32,30 +30,40 @@ go-generate: \
 	precision_string.go \
 	pkg/serial/baudrate_string.go
 
-coordinatesystem_string.go: coordinatesystem.go $(stringer)
-	$(stringer) -type CoordinateSystem -trimprefix CoordinateSystem -output $@ $<
+stringer := go run -modfile tools/xtools/go.mod golang.org/x/tools/cmd/stringer
 
-datatype_string.go: datatype.go $(stringer)
-	$(stringer) -type DataType -trimprefix DataType -output $@ $<
+coordinatesystem_string.go: coordinatesystem.go tools/xtools/go.mod
+	$(info generating $@...)
+	@$(stringer) -type CoordinateSystem -trimprefix CoordinateSystem -output $@ $<
 
-errorcode_string.go: errorcode.go $(stringer)
-	$(stringer) -type ErrorCode -trimprefix ErrorCode -output $@ $<
+datatype_string.go: datatype.go tools/xtools/go.mod
+	$(info generating $@...)
+	@$(stringer) -type DataType -trimprefix DataType -output $@ $<
 
-fixtype_string.go: fixtype.go $(stringer)
-	$(stringer) -type FixType -trimprefix FixType -output $@ $<
+errorcode_string.go: errorcode.go tools/xtools/go.mod
+	$(info generating $@...)
+	@$(stringer) -type ErrorCode -trimprefix ErrorCode -output $@ $<
 
-messageidentifier_string.go: messageidentifier.go $(stringer)
-	$(stringer) -type MessageIdentifier -trimprefix MessageIdentifier -output $@ $<
+fixtype_string.go: fixtype.go tools/xtools/go.mod
+	$(info generating $@...)
+	@$(stringer) -type FixType -trimprefix FixType -output $@ $<
 
-precision_string.go: precision.go $(stringer)
-	$(stringer) -type Precision -trimprefix Precision -output $@ $<
+messageidentifier_string.go: messageidentifier.go tools/xtools/go.mod
+	$(info generating $@...)
+	@$(stringer) -type MessageIdentifier -trimprefix MessageIdentifier -output $@ $<
 
-pkg/serial/baudrate_string.go: pkg/serial/baudrate.go $(stringer)
-	$(stringer) -type BaudRate -trimprefix BaudRate -output $@ $<
+precision_string.go: precision.go tools/xtools/go.mod
+	$(info generating $@...)
+	@$(stringer) -type Precision -trimprefix Precision -output $@ $<
+
+pkg/serial/baudrate_string.go: pkg/serial/baudrate.go tools/xtools/go.mod
+	$(info generating $@...)
+	@$(stringer) -type BaudRate -trimprefix BaudRate -output $@ $<
 
 .PHONY: mockgen-generate
 mockgen-generate: test/mocks/xsens/mocks.go
 
-test/mocks/xsens/mocks.go: client.go $(mockgen)
-	$(mockgen) -destination $@ -package mockxsens \
+test/mocks/xsens/mocks.go: client.go go.mod
+	go run github.com/golang/mock/mockgen \
+		-destination $@ -package mockxsens \
 		github.com/einride/xsens-go SerialPort

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module github.com/einride/xsens-go
 go 1.14
 
 require (
-	github.com/golang/mock v1.3.1
+	github.com/golang/mock v1.4.3
 	github.com/pmezard/go-difflib v1.0.0
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
-	golang.org/x/tools v0.0.0-20190624222133-a101b041ded4
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+	golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666
 	gotest.tools/v3 v3.0.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
-github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
+github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -11,8 +11,14 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666 h1:gVCS+QOncANNPlmlO1AhlU3oxs4V9z+gTtPwIk3p2N8=
+golang.org/x/sys v0.0.0-20200720211630-cb9d2d5c5666/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
@@ -20,3 +26,7 @@ golang.org/x/tools v0.0.0-20190624222133-a101b041ded4 h1:1mMox4TgefDwqluYCv677yN
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+rsc.io/quote/v3 v3.1.0 h1:9JKUTTIUgS6kzR9mK1YuGKv6Nl+DijDNIc0ghT58FaY=
+rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,0 @@
-// +build tools
-
-package tools
-
-import (
-	_ "golang.org/x/tools/cmd/stringer"
-)

--- a/tools/gomock/rules.mk
+++ b/tools/gomock/rules.mk
@@ -1,5 +1,0 @@
-gomock_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-mockgen := $(gomock_cwd)/bin/mockgen
-
-$(mockgen): $(gomock_cwd)/../../go.mod
-	go build -o $@ github.com/golang/mock/mockgen

--- a/tools/xtools/go.mod
+++ b/tools/xtools/go.mod
@@ -1,4 +1,4 @@
-module tools/x/tools
+module tools/xtools
 
 go 1.14
 

--- a/tools/xtools/rules.mk
+++ b/tools/xtools/rules.mk
@@ -1,8 +1,0 @@
-x_tools_cwd := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-stringer := $(x_tools_cwd)/bin/stringer
-export PATH := $(dir $(stringer)):$(PATH)
-
-$(stringer): $(x_tools_cwd)/go.mod
-	@echo building stringer...
-	@cd $(x_tools_cwd) && go build -o $@ golang.org/x/tools/cmd/stringer
-	@cd $(x_tools_cwd) && go mod tidy


### PR DESCRIPTION
Can use go run with -modfile to avoid managing a built binary for tools
such as `stringer`.
