### PR TITLE
Add Mock UDP interface emulator

### DIFF
--- a/emulator.go
+++ b/emulator.go
@@ -2,15 +2,63 @@ package xsens
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"sync"
+	"time"
 )
 
+type UDPSerialPort struct {
+	OriginConn      *net.UDPConn
+	DestinationAddr *net.UDPAddr
+}
+
+func NewUDPSerialPort(origin string, destination string) (*UDPSerialPort, error) {
+	udpOriginAddr, err := net.ResolveUDPAddr("udp", origin)
+	if err != nil {
+		return nil, fmt.Errorf("new udp serial port: %w", err)
+	}
+	udpDestinationAddr, err := net.ResolveUDPAddr("udp", destination)
+	if err != nil {
+		return nil, fmt.Errorf("new udp serial port: %w", err)
+	}
+	originConn, err := net.ListenUDP("udp", udpOriginAddr)
+	if err != nil {
+		return nil, fmt.Errorf("new udp serial port: %w", err)
+	}
+	return &UDPSerialPort{
+		OriginConn:      originConn,
+		DestinationAddr: udpDestinationAddr,
+	}, nil
+}
+
+func (t *UDPSerialPort) Read(p []byte) (int, error) {
+	n, _, err := t.OriginConn.ReadFromUDP(p)
+	return n, err
+}
+
+func (t *UDPSerialPort) Write(p []byte) (n int, err error) {
+	return t.OriginConn.WriteToUDP(p, t.DestinationAddr)
+}
+
+func (t *UDPSerialPort) Close() error {
+	return t.OriginConn.Close()
+}
+
+func (t *UDPSerialPort) SetReadDeadline(t2 time.Time) error {
+	return t.OriginConn.SetReadDeadline(t2)
+}
+
+func (t *UDPSerialPort) SetWriteDeadline(t2 time.Time) error {
+	return t.OriginConn.SetWriteDeadline(t2)
+}
+
 type Emulator struct {
-	port io.ReadWriteCloser
+	port SerialPort
 	w    *bufio.Writer
 	sc   *bufio.Scanner
 
@@ -19,7 +67,7 @@ type Emulator struct {
 	lastMessageIdentifier MessageIdentifier
 }
 
-func NewEmulator(p io.ReadWriteCloser) *Emulator {
+func NewEmulator(p SerialPort) *Emulator {
 	sc := bufio.NewScanner(p)
 	sc.Split(ScanMessages)
 	return &Emulator{
@@ -44,8 +92,15 @@ func (e *Emulator) SetSendMode() {
 	e.lastMessageIdentifier = MessageIdentifierMTData2
 }
 
-func (e *Emulator) Receive() error {
+func (e *Emulator) Receive(ctx context.Context) error {
 	for {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return fmt.Errorf("no deadline")
+		}
+		if err := e.port.SetReadDeadline(deadline); err != nil {
+			return fmt.Errorf("xsens client: receive: %w", err)
+		}
 		if !e.sc.Scan() {
 			if e.sc.Err() != nil {
 				return fmt.Errorf("receive: %w", e.sc.Err())


### PR DESCRIPTION
When emulating the Serial port with udp the mock udp interface
is useful.