### PR TITLE
feat(utcvalidity): Add bitmask constants for UTC validation flags

### DIFF
--- a/measurementdata_test.go
+++ b/measurementdata_test.go
@@ -244,7 +244,7 @@ func TestConvert_GNSSPVTData(t *testing.T) {
 				Hour:      6,
 				Min:       7,
 				Sec:       8,
-				Valid:     9,
+				Valid:     UTCDateValidFlag | UTCTimeOfDayValidFlag | UTCTimeOfDayValidFlag,
 				TAcc:      10,
 				Nano:      11,
 				FixType:   12,
@@ -386,7 +386,7 @@ func TestConvert_UTCTime(t *testing.T) {
 				Hour:   5,
 				Minute: 6,
 				Second: 7,
-				Valid:  8,
+				Valid:  UTCDateValidFlag | UTCTimeOfDayValidFlag | UTCTimeOfDayFullyResolvedFlag,
 			}
 			data, err := org.marshalMTData2Packet(tt)
 			assert.NilError(t, err)

--- a/utcvalidity.go
+++ b/utcvalidity.go
@@ -3,14 +3,20 @@ package xsens
 // UTCValidity represents the validity of an Xsens UTC timestamp.
 type UTCValidity uint8
 
+const (
+	UTCDateValidFlag              = 0x01
+	UTCTimeOfDayValidFlag         = 0x02
+	UTCTimeOfDayFullyResolvedFlag = 0x04
+)
+
 func (u UTCValidity) IsDateValid() bool {
-	return u&0x01 > 0
+	return u&UTCDateValidFlag > 0
 }
 
 func (u UTCValidity) IsTimeOfDayValid() bool {
-	return u&0x02 > 0
+	return u&UTCTimeOfDayValidFlag > 0
 }
 
 func (u UTCValidity) IsTimeOfDayFullyResolved() bool {
-	return u&0x04 > 0
+	return u&UTCTimeOfDayFullyResolvedFlag > 0
 }

--- a/utcvalidity_test.go
+++ b/utcvalidity_test.go
@@ -1,0 +1,31 @@
+package xsens
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestIsDateValid(t *testing.T) {
+	invalid := UTCValidity(0)
+	assert.Assert(t, !invalid.IsDateValid())
+
+	valid := UTCValidity(0 | UTCDateValidFlag)
+	assert.Assert(t, valid.IsDateValid())
+}
+
+func TestIsTimeOfDayValid(t *testing.T) {
+	invalid := UTCValidity(0)
+	assert.Assert(t, !invalid.IsTimeOfDayValid())
+
+	valid := UTCValidity(0 | UTCTimeOfDayValidFlag)
+	assert.Assert(t, valid.IsTimeOfDayValid())
+}
+
+func TestIsTimeOfDayFullyResolved(t *testing.T) {
+	invalid := UTCValidity(0)
+	assert.Assert(t, !invalid.IsTimeOfDayFullyResolved())
+
+	valid := UTCValidity(0 | UTCTimeOfDayFullyResolvedFlag)
+	assert.Assert(t, valid.IsTimeOfDayFullyResolved())
+}


### PR DESCRIPTION
If we want to send valid xsens messages we need to have a way to
create valid UTC timestamps, these flags can aid the readability and
avoid magic constants in such code.