### PR TITLE
fix: move output configuration error

### DIFF
--- a/xsensemulator/emulator.go
+++ b/xsensemulator/emulator.go
@@ -13,7 +13,10 @@ import (
 	"go.einride.tech/xsens"
 )
 
-var ErrNotInMeasurementMode = errors.New("not in measurement mode")
+var (
+	ErrNotInMeasurementMode     = errors.New("not in measurement mode")
+	ErrNotInOutputConfiguration = errors.New("not in output configuration")
+)
 
 type UDPSerialPort struct {
 	OriginConn      *net.UDPConn
@@ -180,7 +183,7 @@ func (e *Emulator) MarshalMessage(measurement xsens.MeasurementData, dataType xs
 		id = d.DataIdentifier
 	}
 	if !isSet {
-		return nil, errors.New("not in output configuration")
+		return nil, ErrNotInOutputConfiguration
 	}
 	packetData, err := measurement.MarshalMTData2Packet(id)
 	if err != nil {


### PR DESCRIPTION
With the error moved out into a variable it is now comparable.