### PR TITLE
chore: add dependabot cooldown settings to mitigate ongoing supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
 
     cooldown:
       default-days: 7
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: weekly
 
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -16,6 +21,11 @@ updates:
         patterns:
           - "*"  # Include all go dependencies in one PR
 
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
   - package-ecosystem: gomod
     directory: .sage
     schedule:
@@ -25,3 +35,8 @@ updates:
       sage-go-dependencies:
         patterns:
           - "*"  # Include all sage dependencies in one PR
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
 
     cooldown:
       default-days: 7
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -23,6 +27,10 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*
   - package-ecosystem: gomod
     directory: .sage
     schedule:
@@ -37,3 +45,7 @@ updates:
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+      exclude:
+        - github.com/einride/*
+        - github.com/einride-autonomous/*
+        - github.com/einride-labs/*


### PR DESCRIPTION
## Summary

Adds `cooldown` configuration to every package ecosystem in `.github/dependabot.yml` to reduce exposure to ongoing supply chain attacks by limiting how quickly compromised or malicious package versions can be automatically adopted.

```yaml
cooldown:
  default-days: 7
  semver-major-days: 30
  semver-minor-days: 7
  semver-patch-days: 3
  exclude:
    - github.com/einride/*
    - github.com/einride-autonomous/*
    - github.com/einride-labs/*
```

Security updates are automatically exempt from this cooldown.
